### PR TITLE
Show local times for match dates

### DIFF
--- a/src/views/Matches/Matches.tsx
+++ b/src/views/Matches/Matches.tsx
@@ -71,19 +71,21 @@ export function Matches(props: MatchesProps) {
           </TableHead>
           <TableBody>
             {matches.map(match => {
-              // Remember, match dates look like: 2024-01-04T09:00Z
-              const startDate = match.startDate.substring(0, 10)
-              const startTime = match.startDate.substring(11, 16)
-              const endTime = match.endDate.substring(11, 16)
+              const start = new Date(match.startDate)
+              const end = new Date(match.endDate)
+              const formatTime = (date: Date): string =>
+                `${date.getHours().toString().padStart(2, '0')}:${date.getMinutes().toString().padStart(2, '0')}`
+              const formatDate = (date: Date): string =>
+                `${date.getDate().toString().padStart(2, '0')}-${(date.getMonth() + 1).toString().padStart(2, '0')}-${date.getFullYear()}`
 
               return (
                 <TableRow key={match.matchId}>
                   <TableCell>
                     <Chip size="small" label={match.sport} />
                   </TableCell>
-                  <TableCell>{startDate}</TableCell>
-                  <TableCell>{startTime}</TableCell>
-                  <TableCell>{endTime}</TableCell>
+                  <TableCell>{formatDate(start)}</TableCell>
+                  <TableCell>{formatTime(start)}</TableCell>
+                  <TableCell>{formatTime(end)}</TableCell>
                   <TableCell align="left">
                     <AvatarGroup max={4} sx={{ flexDirection: 'row' }}>
                       {match.teams


### PR DESCRIPTION
## Summary of the changes

Parse the dates on matches table using `Date` so they can be displayed according to browser local-time.

Before these changes we were manipulating the date as a string; which led to incorrect results because the API **always** returns UTC times. This meant the dates/times would be incorrect for anyone visiting from non-UTC timezones (i.e.: most of the world at some point in the year).

## Motivation

This bug got reported by US clubs to our customer-support team. See [Ticket#123](#not-a-real-link) for the original report.